### PR TITLE
Add initial goo blocks

### DIFF
--- a/src/main/java/com/stevenrs11/greygoo/AirEaterBlock.java
+++ b/src/main/java/com/stevenrs11/greygoo/AirEaterBlock.java
@@ -1,0 +1,55 @@
+package com.stevenrs11.greygoo;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LightLayer;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+
+public class AirEaterBlock extends Block {
+    public AirEaterBlock() {
+        super(BlockBehaviour.Properties.copy(Blocks.STONE).randomTicks());
+    }
+
+    private void spread(ServerLevel level, BlockPos pos) {
+        boolean hasFood = false;
+        for (Direction dir : Direction.values()) {
+            BlockPos target = pos.relative(dir);
+            BlockState targetState = level.getBlockState(target);
+            if (targetState.is(GreyGooMod.CLEANER_BLOCK.get())) {
+                level.setBlockAndUpdate(pos, GreyGooMod.CLEANER_BLOCK.get().defaultBlockState());
+                return;
+            }
+            if (targetState.isAir() && level.getBrightness(LightLayer.BLOCK, target) > 7) {
+                level.setBlockAndUpdate(target, defaultBlockState());
+                hasFood = true;
+            }
+        }
+        if (!hasFood) {
+            level.destroyBlock(pos, false);
+        }
+    }
+
+    @Override
+    public void randomTick(BlockState state, ServerLevel level, BlockPos pos, RandomSource random) {
+        spread(level, pos);
+    }
+
+    @Override
+    public InteractionResult use(BlockState state, Level level, BlockPos pos, Player player,
+            InteractionHand hand, BlockHitResult hit) {
+        if (!level.isClientSide) {
+            spread((ServerLevel) level, pos);
+        }
+        return InteractionResult.SUCCESS;
+    }
+}

--- a/src/main/java/com/stevenrs11/greygoo/CleanerBlock.java
+++ b/src/main/java/com/stevenrs11/greygoo/CleanerBlock.java
@@ -1,0 +1,53 @@
+package com.stevenrs11.greygoo;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+
+public class CleanerBlock extends Block {
+    public CleanerBlock() {
+        super(BlockBehaviour.Properties.copy(Blocks.STONE).randomTicks());
+    }
+
+    private void clean(ServerLevel level, BlockPos pos) {
+        boolean found = false;
+        for (Direction dir : Direction.values()) {
+            BlockPos target = pos.relative(dir);
+            BlockState targetState = level.getBlockState(target);
+            if (targetState.is(GreyGooMod.CLEANER_BLOCK.get())) {
+                continue;
+            }
+            if (GreyGooMod.isGoo(targetState.getBlock())) {
+                level.setBlockAndUpdate(target, defaultBlockState());
+                found = true;
+            }
+        }
+        if (!found) {
+            level.destroyBlock(pos, false);
+        }
+    }
+
+    @Override
+    public void randomTick(BlockState state, ServerLevel level, BlockPos pos, RandomSource random) {
+        clean(level, pos);
+    }
+
+    @Override
+    public InteractionResult use(BlockState state, Level level, BlockPos pos, Player player,
+            InteractionHand hand, BlockHitResult hit) {
+        if (!level.isClientSide) {
+            clean((ServerLevel) level, pos);
+        }
+        return InteractionResult.SUCCESS;
+    }
+}

--- a/src/main/java/com/stevenrs11/greygoo/GreyGooBlock.java
+++ b/src/main/java/com/stevenrs11/greygoo/GreyGooBlock.java
@@ -1,0 +1,63 @@
+package com.stevenrs11.greygoo;
+
+import java.util.Set;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+
+public class GreyGooBlock extends Block {
+    private static final Set<Block> NEVER_EAT = Set.of(
+            Blocks.BEDROCK,
+            Blocks.CHEST,
+            Blocks.ENDER_CHEST
+    );
+
+    public GreyGooBlock() {
+        super(BlockBehaviour.Properties.copy(Blocks.STONE).randomTicks());
+    }
+
+    private void spread(ServerLevel level, BlockPos pos) {
+        boolean hasFood = false;
+        for (Direction dir : Direction.values()) {
+            BlockPos target = pos.relative(dir);
+            BlockState targetState = level.getBlockState(target);
+            Block block = targetState.getBlock();
+            if (block == GreyGooMod.CLEANER_BLOCK.get()) {
+                level.setBlockAndUpdate(pos, GreyGooMod.CLEANER_BLOCK.get().defaultBlockState());
+                return;
+            }
+            if (!targetState.isAir() && !NEVER_EAT.contains(block)) {
+                level.setBlockAndUpdate(target, defaultBlockState());
+                hasFood = true;
+            }
+        }
+        if (!hasFood) {
+            level.destroyBlock(pos, false);
+        }
+    }
+
+    @Override
+    public void randomTick(BlockState state, ServerLevel level, BlockPos pos, RandomSource random) {
+        spread(level, pos);
+    }
+
+    @Override
+    public InteractionResult use(BlockState state, Level level, BlockPos pos, Player player,
+            InteractionHand hand, BlockHitResult hit) {
+        if (!level.isClientSide) {
+            spread((ServerLevel) level, pos);
+        }
+        return InteractionResult.SUCCESS;
+    }
+}

--- a/src/main/java/com/stevenrs11/greygoo/GreyGooMod.java
+++ b/src/main/java/com/stevenrs11/greygoo/GreyGooMod.java
@@ -5,12 +5,16 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
+
+import java.util.Set;
+
 
 @Mod(GreyGooMod.MODID)
 public class GreyGooMod {
@@ -23,15 +27,46 @@ public class GreyGooMod {
 
     public static final RegistryObject<Block> GREY_GOO_BLOCK = BLOCKS.register(
             "grey_goo_block",
-            () -> new Block(BlockBehaviour.Properties.copy(Blocks.STONE)));
+            GreyGooBlock::new);
+
+    public static final RegistryObject<Block> CLEANER_BLOCK = BLOCKS.register(
+            "cleaner_block",
+            CleanerBlock::new);
+
+    public static final RegistryObject<Block> AIR_EATER_BLOCK = BLOCKS.register(
+            "air_eater_block",
+            AirEaterBlock::new);
+
+    public static final RegistryObject<Block> WATER_EATER_BLOCK = BLOCKS.register(
+            "water_eater_block",
+            WaterEaterBlock::new);
 
     public static final RegistryObject<Item> GREY_GOO_BLOCK_ITEM = ITEMS.register(
             "grey_goo_block",
             () -> new BlockItem(GREY_GOO_BLOCK.get(), new Item.Properties()));
 
+    public static final RegistryObject<Item> CLEANER_BLOCK_ITEM = ITEMS.register(
+            "cleaner_block",
+            () -> new BlockItem(CLEANER_BLOCK.get(), new Item.Properties()));
+
+    public static final RegistryObject<Item> AIR_EATER_BLOCK_ITEM = ITEMS.register(
+            "air_eater_block",
+            () -> new BlockItem(AIR_EATER_BLOCK.get(), new Item.Properties()));
+
+    public static final RegistryObject<Item> WATER_EATER_BLOCK_ITEM = ITEMS.register(
+            "water_eater_block",
+            () -> new BlockItem(WATER_EATER_BLOCK.get(), new Item.Properties()));
+
     public GreyGooMod() {
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
         BLOCKS.register(modEventBus);
         ITEMS.register(modEventBus);
+    }
+
+    public static boolean isGoo(Block block) {
+        return block == GREY_GOO_BLOCK.get()
+                || block == CLEANER_BLOCK.get()
+                || block == AIR_EATER_BLOCK.get()
+                || block == WATER_EATER_BLOCK.get();
     }
 }

--- a/src/main/java/com/stevenrs11/greygoo/WaterEaterBlock.java
+++ b/src/main/java/com/stevenrs11/greygoo/WaterEaterBlock.java
@@ -1,0 +1,55 @@
+package com.stevenrs11.greygoo;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.tags.FluidTags;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+
+public class WaterEaterBlock extends Block {
+    public WaterEaterBlock() {
+        super(BlockBehaviour.Properties.copy(Blocks.STONE).randomTicks());
+    }
+
+    private void spread(ServerLevel level, BlockPos pos) {
+        boolean hasFood = false;
+        for (Direction dir : Direction.values()) {
+            BlockPos target = pos.relative(dir);
+            BlockState targetState = level.getBlockState(target);
+            if (targetState.is(GreyGooMod.CLEANER_BLOCK.get())) {
+                level.setBlockAndUpdate(pos, GreyGooMod.CLEANER_BLOCK.get().defaultBlockState());
+                return;
+            }
+            if (targetState.getFluidState().is(FluidTags.WATER) || targetState.getFluidState().is(FluidTags.LAVA)) {
+                level.setBlockAndUpdate(target, defaultBlockState());
+                hasFood = true;
+            }
+        }
+        if (!hasFood) {
+            level.destroyBlock(pos, false);
+        }
+    }
+
+    @Override
+    public void randomTick(BlockState state, ServerLevel level, BlockPos pos, RandomSource random) {
+        spread(level, pos);
+    }
+
+    @Override
+    public InteractionResult use(BlockState state, Level level, BlockPos pos, Player player,
+            InteractionHand hand, BlockHitResult hit) {
+        if (!level.isClientSide) {
+            spread((ServerLevel) level, pos);
+        }
+        return InteractionResult.SUCCESS;
+    }
+}

--- a/src/main/resources/assets/greygoo/blockstates/air_eater_block.json
+++ b/src/main/resources/assets/greygoo/blockstates/air_eater_block.json
@@ -1,0 +1,5 @@
+{
+  "variants": {
+    "": {"model": "greygoo:block/air_eater_block"}
+  }
+}

--- a/src/main/resources/assets/greygoo/blockstates/cleaner_block.json
+++ b/src/main/resources/assets/greygoo/blockstates/cleaner_block.json
@@ -1,0 +1,5 @@
+{
+  "variants": {
+    "": {"model": "greygoo:block/cleaner_block"}
+  }
+}

--- a/src/main/resources/assets/greygoo/blockstates/water_eater_block.json
+++ b/src/main/resources/assets/greygoo/blockstates/water_eater_block.json
@@ -1,0 +1,5 @@
+{
+  "variants": {
+    "": {"model": "greygoo:block/water_eater_block"}
+  }
+}

--- a/src/main/resources/assets/greygoo/lang/en_us.json
+++ b/src/main/resources/assets/greygoo/lang/en_us.json
@@ -1,3 +1,6 @@
 {
   "block.greygoo.grey_goo_block": "Grey Goo Block"
+  ,"block.greygoo.cleaner_block": "Cleaner"
+  ,"block.greygoo.air_eater_block": "Air Eater"
+  ,"block.greygoo.water_eater_block": "Water Eater"
 }

--- a/src/main/resources/assets/greygoo/models/block/air_eater_block.json
+++ b/src/main/resources/assets/greygoo/models/block/air_eater_block.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:block/cube_all",
+  "textures": {
+    "all": "minecraft:block/stone"
+  }
+}

--- a/src/main/resources/assets/greygoo/models/block/cleaner_block.json
+++ b/src/main/resources/assets/greygoo/models/block/cleaner_block.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:block/cube_all",
+  "textures": {
+    "all": "minecraft:block/stone"
+  }
+}

--- a/src/main/resources/assets/greygoo/models/block/water_eater_block.json
+++ b/src/main/resources/assets/greygoo/models/block/water_eater_block.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:block/cube_all",
+  "textures": {
+    "all": "minecraft:block/stone"
+  }
+}

--- a/src/main/resources/assets/greygoo/models/item/air_eater_block.json
+++ b/src/main/resources/assets/greygoo/models/item/air_eater_block.json
@@ -1,0 +1,3 @@
+{
+  "parent": "greygoo:block/air_eater_block"
+}

--- a/src/main/resources/assets/greygoo/models/item/cleaner_block.json
+++ b/src/main/resources/assets/greygoo/models/item/cleaner_block.json
@@ -1,0 +1,3 @@
+{
+  "parent": "greygoo:block/cleaner_block"
+}

--- a/src/main/resources/assets/greygoo/models/item/water_eater_block.json
+++ b/src/main/resources/assets/greygoo/models/item/water_eater_block.json
@@ -1,0 +1,3 @@
+{
+  "parent": "greygoo:block/water_eater_block"
+}


### PR DESCRIPTION
## Summary
- port Grey Goo, Cleaner, Air Eater and Water Eater blocks
- register each block and its item form
- add blockstate, model, and lang data

## Testing
- `gradle wrapper`
- `./gradlew build` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6846ed1d11ac8323a43ed2ed25a9f5f7