### PR TITLE
Fix creative tab registration

### DIFF
--- a/src/main/java/com/stevenrs11/greygoo/GreyGooCreativeTabs.java
+++ b/src/main/java/com/stevenrs11/greygoo/GreyGooCreativeTabs.java
@@ -5,12 +5,12 @@ import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.registries.DeferredRegister;
-import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraft.core.registries.Registries;
 import net.minecraftforge.registries.RegistryObject;
 
 public class GreyGooCreativeTabs {
     public static final DeferredRegister<CreativeModeTab> TABS =
-            DeferredRegister.create(ForgeRegistries.CREATIVE_MODE_TABS, GreyGooMod.MODID);
+            DeferredRegister.create(Registries.CREATIVE_MODE_TAB, GreyGooMod.MODID);
 
     public static final RegistryObject<CreativeModeTab> MAIN = TABS.register("greygoo",
             () -> CreativeModeTab.builder()
@@ -18,6 +18,9 @@ public class GreyGooCreativeTabs {
                     .icon(() -> new ItemStack(GreyGooMod.GREY_GOO_BLOCK_ITEM.get()))
                     .displayItems((params, output) -> {
                         output.accept(GreyGooMod.GREY_GOO_BLOCK_ITEM.get());
+                        output.accept(GreyGooMod.CLEANER_BLOCK_ITEM.get());
+                        output.accept(GreyGooMod.AIR_EATER_BLOCK_ITEM.get());
+                        output.accept(GreyGooMod.WATER_EATER_BLOCK_ITEM.get());
                     })
                     .build());
 


### PR DESCRIPTION
## Summary
- register the creative tab using the proper registry constant
- include all block items when listing display items

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_6846f31e3fa083239ea5cea797e0d24d