### PR TITLE
Add texture splitting utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,12 @@ The compiled jar will appear in `build/libs/`. You can place this file in your M
 ## Notes
 - The provided code only includes a basic block to verify that the mod loads on 1.20.1. More of the original mod features will need to be ported manually.
 - Textures are borrowed from vanilla (`minecraft:block/stone`) to keep things simple. You can replace them with the originals under `assets/greygoo`.
+
+## Texture Utility
+Use `tools/split_textures.py` to slice the provided texture atlases into
+individual 16x16 PNG files. For example:
+```bash
+python tools/split_textures.py GooBlockTextures.png GooItemTextures.png
+```
+Tiles are written to folders next to each source image with placeholder
+names like `tile_000.png`.

--- a/tools/split_textures.py
+++ b/tools/split_textures.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Split texture atlases into 16x16 PNG tiles.
+
+Usage:
+    python split_textures.py input.png [input2.png ...] [-o OUTPUT_DIR]
+
+If OUTPUT_DIR is not provided, tiles will be written next to the
+input file inside a folder named after it.
+"""
+import argparse
+from pathlib import Path
+from PIL import Image
+
+
+def split_image(path: Path, output_dir: Path) -> None:
+    img = Image.open(path)
+    width, height = img.size
+    if width % 16 or height % 16:
+        raise ValueError(f"Image {path} size {width}x{height} is not divisible by 16")
+    cols, rows = width // 16, height // 16
+    output_dir.mkdir(parents=True, exist_ok=True)
+    count = 0
+    for y in range(rows):
+        for x in range(cols):
+            tile = img.crop((x * 16, y * 16, (x + 1) * 16, (y + 1) * 16))
+            tile_path = output_dir / f"tile_{count:03d}.png"
+            tile.save(tile_path)
+            count += 1
+    print(f"Wrote {count} tiles to {output_dir}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Split texture atlases into 16x16 tiles")
+    parser.add_argument('images', nargs='+', help='Input PNG files to split')
+    parser.add_argument('-o', '--output', help='Directory to place extracted tiles')
+    args = parser.parse_args()
+
+    for image_path in args.images:
+        p = Path(image_path)
+        if not p.is_file():
+            print(f"Skipping missing file: {p}")
+            continue
+        out_dir = Path(args.output) if args.output else p.with_suffix('')
+        split_image(p, out_dir)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `tools/split_textures.py` to slice texture atlases into 16x16 tiles
- document the new utility in the README

## Testing
- `python tools/split_textures.py GooBlockTextures.png -o test_output`
- `python tools/split_textures.py GooBlockTextures.png`
- `javac -version`
- `./gradlew --version` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_6846fe7d10508323a0a6a5aaf3267dfb