### PR TITLE
Improve cleaner block spread logic

### DIFF
--- a/src/main/java/com/stevenrs11/greygoo/CleanerBlock.java
+++ b/src/main/java/com/stevenrs11/greygoo/CleanerBlock.java
@@ -1,7 +1,6 @@
 package com.stevenrs11.greygoo;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.InteractionHand;
@@ -15,21 +14,32 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
 
 public class CleanerBlock extends Block {
+    private static final int RADIUS = 2;
     public CleanerBlock() {
         super(BlockBehaviour.Properties.copy(Blocks.STONE).randomTicks());
     }
 
     private void clean(ServerLevel level, BlockPos pos) {
         boolean found = false;
-        for (Direction dir : Direction.values()) {
-            BlockPos target = pos.relative(dir);
-            BlockState targetState = level.getBlockState(target);
-            if (targetState.is(GreyGooMod.CLEANER_BLOCK.get())) {
-                continue;
-            }
-            if (GreyGooMod.isGoo(targetState.getBlock())) {
-                level.setBlockAndUpdate(target, defaultBlockState());
-                found = true;
+        for (int dx = -RADIUS; dx <= RADIUS; dx++) {
+            for (int dy = -RADIUS; dy <= RADIUS; dy++) {
+                for (int dz = -RADIUS; dz <= RADIUS; dz++) {
+                    if (dx == 0 && dy == 0 && dz == 0) {
+                        continue;
+                    }
+                    if (Math.abs(dx) + Math.abs(dy) + Math.abs(dz) > RADIUS) {
+                        continue;
+                    }
+                    BlockPos target = pos.offset(dx, dy, dz);
+                    BlockState targetState = level.getBlockState(target);
+                    if (targetState.is(GreyGooMod.CLEANER_BLOCK.get())) {
+                        continue;
+                    }
+                    if (GreyGooMod.isGoo(targetState.getBlock())) {
+                        level.setBlockAndUpdate(target, defaultBlockState());
+                        found = true;
+                    }
+                }
             }
         }
         if (!found) {


### PR DESCRIPTION
## Summary
- expand cleaner block's search radius so it cleans goo blocks up to two blocks away, matching original mod behavior

## Testing
- `javac -version`
- `./gradlew build` *(fails: could not resolve Forge dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6846fde5b560832380a34300d057914b