### PR TITLE
Fix Gravity Goo textures

### DIFF
--- a/src/main/resources/assets/greygoo/blockstates/gravity_goo_block.json
+++ b/src/main/resources/assets/greygoo/blockstates/gravity_goo_block.json
@@ -1,0 +1,5 @@
+{
+  "variants": {
+    "": {"model": "greygoo:block/gravity_goo_block"}
+  }
+}

--- a/src/main/resources/assets/greygoo/models/block/gravity_goo_block.json
+++ b/src/main/resources/assets/greygoo/models/block/gravity_goo_block.json
@@ -1,6 +1,6 @@
 {
   "parent": "minecraft:block/cube_all",
   "textures": {
-    "all": "greygoo:block/tile_007"
+    "all": "greygoo:block/gravity_goo_block"
   }
 }


### PR DESCRIPTION
## Summary
- register missing gravity goo blockstate
- point gravity goo block model to named texture instead of tile

## Testing
- `javac -version`
- `./gradlew build` *(fails: process stuck downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68477968bb748323a3e68d06b8653040