### PR TITLE
Implement RapidWaterEater block

### DIFF
--- a/src/main/java/com/stevenrs11/greygoo/GreyGooCreativeTabs.java
+++ b/src/main/java/com/stevenrs11/greygoo/GreyGooCreativeTabs.java
@@ -21,6 +21,7 @@ public class GreyGooCreativeTabs {
                         output.accept(GreyGooMod.CLEANER_BLOCK_ITEM.get());
                         output.accept(GreyGooMod.AIR_EATER_BLOCK_ITEM.get());
                         output.accept(GreyGooMod.WATER_EATER_BLOCK_ITEM.get());
+                        output.accept(GreyGooMod.RAPID_WATER_EATER_BLOCK_ITEM.get());
                         output.accept(GreyGooMod.GRAVITY_GOO_BLOCK_ITEM.get());
                         output.accept(GreyGooMod.REDYELLOW_BLOCK_ITEM.get());
                     })

--- a/src/main/java/com/stevenrs11/greygoo/GreyGooMod.java
+++ b/src/main/java/com/stevenrs11/greygoo/GreyGooMod.java
@@ -44,6 +44,10 @@ public class GreyGooMod {
             "water_eater_block",
             WaterEaterBlock::new);
 
+    public static final RegistryObject<Block> RAPID_WATER_EATER_BLOCK = BLOCKS.register(
+            "rapid_water_eater_block",
+            RapidWaterEaterBlock::new);
+
     public static final RegistryObject<Block> GRAVITY_GOO_BLOCK = BLOCKS.register(
             "gravity_goo_block",
             GravityGooBlock::new);
@@ -68,6 +72,10 @@ public class GreyGooMod {
             "water_eater_block",
             () -> new BlockItem(WATER_EATER_BLOCK.get(), new Item.Properties()));
 
+    public static final RegistryObject<Item> RAPID_WATER_EATER_BLOCK_ITEM = ITEMS.register(
+            "rapid_water_eater_block",
+            () -> new BlockItem(RAPID_WATER_EATER_BLOCK.get(), new Item.Properties()));
+
     public static final RegistryObject<Item> GRAVITY_GOO_BLOCK_ITEM = ITEMS.register(
             "gravity_goo_block",
             () -> new BlockItem(GRAVITY_GOO_BLOCK.get(), new Item.Properties()));
@@ -88,6 +96,7 @@ public class GreyGooMod {
                 || block == CLEANER_BLOCK.get()
                 || block == AIR_EATER_BLOCK.get()
                 || block == WATER_EATER_BLOCK.get()
+                || block == RAPID_WATER_EATER_BLOCK.get()
                 || block == GRAVITY_GOO_BLOCK.get()
                 || block == REDYELLOW_BLOCK.get();
     }

--- a/src/main/java/com/stevenrs11/greygoo/RapidWaterEaterBlock.java
+++ b/src/main/java/com/stevenrs11/greygoo/RapidWaterEaterBlock.java
@@ -1,0 +1,89 @@
+package com.stevenrs11.greygoo;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.tags.FluidTags;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.properties.IntegerProperty;
+import net.minecraft.world.phys.BlockHitResult;
+
+public class RapidWaterEaterBlock extends Block {
+    public static final IntegerProperty STAGE = IntegerProperty.create("stage", 0, 50);
+
+    public RapidWaterEaterBlock() {
+        super(BlockBehaviour.Properties.copy(Blocks.STONE).noRandomTicks());
+        this.registerDefaultState(this.stateDefinition.any().setValue(STAGE, 0));
+    }
+
+    @Override
+    protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
+        builder.add(STAGE);
+    }
+
+    private void spreadCube(ServerLevel level, BlockPos pos, BlockState state, boolean removeSelf) {
+        int stage = state.getValue(STAGE);
+        if (stage >= 50) {
+            if (removeSelf) {
+                level.removeBlock(pos, false);
+            }
+            return;
+        }
+        boolean found = false;
+        for (int dx = -1; dx <= 1; dx++) {
+            for (int dy = -1; dy <= 1; dy++) {
+                for (int dz = -1; dz <= 1; dz++) {
+                    if (dx == 0 && dy == 0 && dz == 0) {
+                        continue;
+                    }
+                    BlockPos target = pos.offset(dx, dy, dz);
+                    BlockState targetState = level.getBlockState(target);
+                    if (targetState.is(GreyGooMod.CLEANER_BLOCK.get())) {
+                        level.setBlockAndUpdate(pos, GreyGooMod.CLEANER_BLOCK.get().defaultBlockState());
+                        return;
+                    }
+                    if (targetState.getFluidState().is(FluidTags.WATER) || targetState.getFluidState().is(FluidTags.LAVA)) {
+                        level.setBlockAndUpdate(target, defaultBlockState().setValue(STAGE, stage + 1));
+                        level.scheduleTick(target, this, 5);
+                        found = true;
+                    }
+                }
+            }
+        }
+        if (removeSelf) {
+            level.removeBlock(pos, false);
+        } else if (!found) {
+            level.removeBlock(pos, false);
+        }
+    }
+
+    @Override
+    public void tick(BlockState state, ServerLevel level, BlockPos pos, RandomSource random) {
+        spreadCube(level, pos, state, true);
+    }
+
+    @Override
+    public InteractionResult use(BlockState state, Level level, BlockPos pos, Player player,
+            InteractionHand hand, BlockHitResult hit) {
+        if (!level.isClientSide && !player.isCrouching()) {
+            spreadCube((ServerLevel) level, pos, state.setValue(STAGE, 0), false);
+            return InteractionResult.SUCCESS;
+        }
+        return InteractionResult.PASS;
+    }
+
+    @Override
+    public void onPlace(BlockState state, Level level, BlockPos pos, BlockState oldState, boolean isMoving) {
+        if (!level.isClientSide && state.getValue(STAGE) > 0) {
+            level.scheduleTick(pos, this, 5);
+        }
+    }
+}

--- a/src/main/java/com/stevenrs11/greygoo/RapidWaterEaterBlock.java
+++ b/src/main/java/com/stevenrs11/greygoo/RapidWaterEaterBlock.java
@@ -52,7 +52,7 @@ public class RapidWaterEaterBlock extends Block {
                     }
                     if (targetState.getFluidState().is(FluidTags.WATER) || targetState.getFluidState().is(FluidTags.LAVA)) {
                         level.setBlockAndUpdate(target, defaultBlockState().setValue(STAGE, stage + 1));
-                        level.scheduleTick(target, this, 5);
+                        level.scheduleTick(target, this, level.getRandom().nextInt(3));
                         found = true;
                     }
                 }
@@ -83,7 +83,7 @@ public class RapidWaterEaterBlock extends Block {
     @Override
     public void onPlace(BlockState state, Level level, BlockPos pos, BlockState oldState, boolean isMoving) {
         if (!level.isClientSide && state.getValue(STAGE) > 0) {
-            level.scheduleTick(pos, this, 5);
+            level.scheduleTick(pos, this, level.getRandom().nextInt(3));
         }
     }
 }

--- a/src/main/resources/assets/greygoo/blockstates/rapid_water_eater_block.json
+++ b/src/main/resources/assets/greygoo/blockstates/rapid_water_eater_block.json
@@ -1,0 +1,5 @@
+{
+  "variants": {
+    "": {"model": "greygoo:block/rapid_water_eater_block"}
+  }
+}

--- a/src/main/resources/assets/greygoo/lang/en_us.json
+++ b/src/main/resources/assets/greygoo/lang/en_us.json
@@ -3,6 +3,7 @@
   "block.greygoo.cleaner_block": "Cleaner",
   "block.greygoo.air_eater_block": "Air Eater",
   "block.greygoo.water_eater_block": "Water Eater",
+  "block.greygoo.rapid_water_eater_block": "Blue-Red Goo",
   "itemGroup.greygoo": "Grey Goo",
   "block.greygoo.gravity_goo_block": "Gravity Goo",
   "block.greygoo.redyellow_block": "Redyellow"

--- a/src/main/resources/assets/greygoo/models/block/rapid_water_eater_block.json
+++ b/src/main/resources/assets/greygoo/models/block/rapid_water_eater_block.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:block/cube_all",
+  "textures": {
+    "all": "greygoo:block/redblue_block"
+  }
+}

--- a/src/main/resources/assets/greygoo/models/item/rapid_water_eater_block.json
+++ b/src/main/resources/assets/greygoo/models/item/rapid_water_eater_block.json
@@ -1,0 +1,3 @@
+{
+  "parent": "greygoo:block/rapid_water_eater_block"
+}


### PR DESCRIPTION
## Summary
- add `RapidWaterEaterBlock` with spreading countdown
- register new block and item
- place block on creative tab
- add blockstate/model/translation

## Testing
- `./gradlew build` *(fails: Java toolchain not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6847894ed8208323a2acf0339f0de0f4