### PR TITLE
Add Orange Red block

### DIFF
--- a/src/main/java/com/stevenrs11/greygoo/GreyGooCreativeTabs.java
+++ b/src/main/java/com/stevenrs11/greygoo/GreyGooCreativeTabs.java
@@ -24,6 +24,7 @@ public class GreyGooCreativeTabs {
                         output.accept(GreyGooMod.RAPID_WATER_EATER_BLOCK_ITEM.get());
                         output.accept(GreyGooMod.GRAVITY_GOO_BLOCK_ITEM.get());
                         output.accept(GreyGooMod.REDYELLOW_BLOCK_ITEM.get());
+                        output.accept(GreyGooMod.ORANGE_RED_BLOCK_ITEM.get());
                     })
                     .build());
 

--- a/src/main/java/com/stevenrs11/greygoo/GreyGooMod.java
+++ b/src/main/java/com/stevenrs11/greygoo/GreyGooMod.java
@@ -8,6 +8,7 @@ import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import com.stevenrs11.greygoo.GravityGooBlock;
 import com.stevenrs11.greygoo.RedyellowBlock;
+import com.stevenrs11.greygoo.OrangeRedBlock;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
@@ -56,6 +57,10 @@ public class GreyGooMod {
             "redyellow_block",
             RedyellowBlock::new);
 
+    public static final RegistryObject<Block> ORANGE_RED_BLOCK = BLOCKS.register(
+            "orange_red_block",
+            OrangeRedBlock::new);
+
     public static final RegistryObject<Item> GREY_GOO_BLOCK_ITEM = ITEMS.register(
             "grey_goo_block",
             () -> new BlockItem(GREY_GOO_BLOCK.get(), new Item.Properties()));
@@ -84,6 +89,10 @@ public class GreyGooMod {
             "redyellow_block",
             () -> new BlockItem(REDYELLOW_BLOCK.get(), new Item.Properties()));
 
+    public static final RegistryObject<Item> ORANGE_RED_BLOCK_ITEM = ITEMS.register(
+            "orange_red_block",
+            () -> new BlockItem(ORANGE_RED_BLOCK.get(), new Item.Properties()));
+
     public GreyGooMod() {
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
         GreyGooCreativeTabs.register(modEventBus);
@@ -98,6 +107,7 @@ public class GreyGooMod {
                 || block == WATER_EATER_BLOCK.get()
                 || block == RAPID_WATER_EATER_BLOCK.get()
                 || block == GRAVITY_GOO_BLOCK.get()
-                || block == REDYELLOW_BLOCK.get();
+                || block == REDYELLOW_BLOCK.get()
+                || block == ORANGE_RED_BLOCK.get();
     }
 }

--- a/src/main/java/com/stevenrs11/greygoo/OrangeRedBlock.java
+++ b/src/main/java/com/stevenrs11/greygoo/OrangeRedBlock.java
@@ -1,0 +1,81 @@
+package com.stevenrs11.greygoo;
+
+import java.util.Set;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.tags.FluidTags;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+
+public class OrangeRedBlock extends Block {
+    private static final Set<Block> NEVER_EAT = Set.of(
+            Blocks.BEDROCK,
+            Blocks.CHEST,
+            Blocks.ENDER_CHEST
+    );
+
+    public OrangeRedBlock() {
+        super(BlockBehaviour.Properties.copy(Blocks.STONE).noRandomTicks());
+    }
+
+    private void spread(ServerLevel level, BlockPos pos) {
+        boolean found = false;
+        for (Direction dir : Direction.values()) {
+            BlockPos behind = pos.relative(dir.getOpposite());
+            if (!level.getBlockState(behind).is(this)) {
+                continue;
+            }
+            BlockPos target = pos.relative(dir);
+            BlockState targetState = level.getBlockState(target);
+            Block block = targetState.getBlock();
+            if (block == GreyGooMod.CLEANER_BLOCK.get()) {
+                level.setBlockAndUpdate(pos, GreyGooMod.CLEANER_BLOCK.get().defaultBlockState());
+                return;
+            }
+            if (!targetState.isAir()
+                    && !NEVER_EAT.contains(block)
+                    && !targetState.is(this)
+                    && !targetState.getFluidState().is(FluidTags.WATER)
+                    && !targetState.getFluidState().is(FluidTags.LAVA)) {
+                level.setBlockAndUpdate(target, defaultBlockState());
+                level.scheduleTick(target, this, level.getRandom().nextInt(3) + 1);
+                found = true;
+            }
+        }
+        if (!found) {
+            level.removeBlock(pos, false);
+        }
+    }
+
+    @Override
+    public void tick(BlockState state, ServerLevel level, BlockPos pos, RandomSource random) {
+        spread(level, pos);
+    }
+
+    @Override
+    public InteractionResult use(BlockState state, Level level, BlockPos pos, Player player,
+            InteractionHand hand, BlockHitResult hit) {
+        if (!level.isClientSide && !player.isCrouching()) {
+            spread((ServerLevel) level, pos);
+            return InteractionResult.SUCCESS;
+        }
+        return InteractionResult.PASS;
+    }
+
+    @Override
+    public void onPlace(BlockState state, Level level, BlockPos pos, BlockState oldState, boolean isMoving) {
+        if (!level.isClientSide) {
+            level.scheduleTick(pos, this, 1);
+        }
+    }
+}

--- a/src/main/resources/assets/greygoo/blockstates/orange_red_block.json
+++ b/src/main/resources/assets/greygoo/blockstates/orange_red_block.json
@@ -1,0 +1,5 @@
+{
+  "variants": {
+    "": {"model": "greygoo:block/orange_red_block"}
+  }
+}

--- a/src/main/resources/assets/greygoo/lang/en_us.json
+++ b/src/main/resources/assets/greygoo/lang/en_us.json
@@ -6,5 +6,6 @@
   "block.greygoo.rapid_water_eater_block": "Blue-Red Goo",
   "itemGroup.greygoo": "Grey Goo",
   "block.greygoo.gravity_goo_block": "Gravity Goo",
-  "block.greygoo.redyellow_block": "Redyellow"
+  "block.greygoo.redyellow_block": "Redyellow",
+  "block.greygoo.orange_red_block": "Orange-Red Goo"
 }

--- a/src/main/resources/assets/greygoo/models/block/orange_red_block.json
+++ b/src/main/resources/assets/greygoo/models/block/orange_red_block.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:block/cube_all",
+  "textures": {
+    "all": "greygoo:block/tile_022"
+  }
+}

--- a/src/main/resources/assets/greygoo/models/item/orange_red_block.json
+++ b/src/main/resources/assets/greygoo/models/item/orange_red_block.json
@@ -1,0 +1,3 @@
+{
+  "parent": "greygoo:block/orange_red_block"
+}


### PR DESCRIPTION
## Summary
- add OrangeRedBlock with spreading behavior
- register block and item
- expose on creative tab
- add assets and language entry

## Testing
- `./gradlew build` *(fails: could not resolve Forge dependencies)*
- `./gradlew runClient` *(fails: toolchain spec error)*

------
https://chatgpt.com/codex/tasks/task_e_6847abcdc6d8832394a0566b073fe2f6